### PR TITLE
feat: Ignore SSL errors #15

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -99,6 +99,12 @@ cliArgs =
               <> help "Feed Updated Date Cache File Path"
           )
         <*> switch
+          ( long "insecure"
+              <> short 'k'
+              <> showDefault
+              <> help "Allow insecure server connections when using SSL"
+          )
+        <*> switch
           ( long "dry-run"
               <> showDefault
               <> help "If true, will not post to Mattermost"

--- a/package.yaml
+++ b/package.yaml
@@ -29,8 +29,11 @@ dependencies:
 - base >= 4.7 && < 5
 - aeson
 - bytestring
+- connection
 - containers
 - feed
+- http-client
+- http-client-tls
 - mtl
 - modern-uri
 - mustache

--- a/src/Bot/Api/Qiita.hs
+++ b/src/Bot/Api/Qiita.hs
@@ -1,6 +1,6 @@
 module Bot.Api.Qiita where
 
-import Bot.Api.Util (ReqInfo, reqGet, useStr)
+import Bot.Api.Util (ReqInfo, reqGet, useStr, customHttpConfig)
 import qualified Bot.Util as Util
 import Control.Monad.Except (ExceptT, runExceptT)
 import Data.Text (Text)
@@ -8,13 +8,14 @@ import qualified Network.HTTP.Req as Req
 import qualified Text.Feed.Import as Import
 import Text.Feed.Types (Feed)
 
-getCalendarFeed :: String -> IO (Either Text Feed)
-getCalendarFeed feedUri = runExceptT $ do
+getCalendarFeed :: Bool -> String -> IO (Either Text Feed)
+getCalendarFeed insecure feedUri = runExceptT $ do
   eUrlInfo <- Util.hoistMaybe "Invalid API URL" (useStr feedUri)
   either fetch fetch eUrlInfo
   where
     fetch :: ReqInfo scheme -> ExceptT Text IO Feed
     fetch info = do
       let req = Req.responseBody <$> reqGet info Req.lbsResponse
-      res <- Req.runReq Req.defaultHttpConfig req
+      httpConf <- customHttpConfig insecure
+      res <- Req.runReq httpConf req
       Util.hoistMaybe "Parse RSS Feed Faild" $ Import.parseFeedSource res

--- a/src/Bot/Api/Util.hs
+++ b/src/Bot/Api/Util.hs
@@ -2,9 +2,12 @@
 
 module Bot.Api.Util where
 
+import Control.Monad.IO.Class (MonadIO)
 import Data.Aeson (FromJSON)
 import Data.Proxy (Proxy)
 import qualified Data.Text as Txt
+import Network.Connection (TLSSettings (TLSSettingsSimple))
+import Network.HTTP.Client.TLS (mkManagerSettings, newTlsManagerWith)
 import qualified Network.HTTP.Req as Req
 import Text.URI (mkURI)
 import qualified Text.URI as URI
@@ -30,3 +33,12 @@ reqPost ::
   Proxy res ->
   m res
 reqPost (url, opt) body res = Req.req Req.POST url body res opt
+
+customHttpConfig :: MonadIO m => Bool -> m Req.HttpConfig
+customHttpConfig insecure =
+  if insecure
+    then do
+      let managerSetting = mkManagerSettings (TLSSettingsSimple True False False) Nothing
+      m <- newTlsManagerWith managerSetting
+      return Req.defaultHttpConfig {Req.httpConfigAltManager = Just m}
+    else return Req.defaultHttpConfig

--- a/src/Bot/Data/Args.hs
+++ b/src/Bot/Data/Args.hs
@@ -7,5 +7,6 @@ data Args = Args
     summaryApiKey :: Maybe String,
     templateFilePath :: FilePath,
     cachePath :: FilePath,
+    insecure :: Bool,
     dryRun :: Bool
   }


### PR DESCRIPTION
cURLのようにSSL証明書エラーを無視するオプションを付け加えた。デフォルトではOFFだが、コマンドラインで`-k`または`--insecure`オプションを指定することで有効化できる。

close #15