### PR TITLE
fix: コンテナ内のデフォルトロケールをUTF-8対応に変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM debian:bullseye-slim
 
+ENV LANG=C.UTF-8
 RUN useradd -m bot
 ADD ./advent-calendar-bot-Linux.tar.gz /home/bot
 RUN ln -s /home/bot/advent-calendar-bot/advent-calendar-bot-exe /usr/local/bin/advent-calendar-bot-exe


### PR DESCRIPTION
fix: #31 